### PR TITLE
Fix banking and bag fall regressions

### DIFF
--- a/ZGB-template-master/include/StateGame.h
+++ b/ZGB-template-master/include/StateGame.h
@@ -67,7 +67,7 @@
 #define LARGE_TILE_FROM_PIXEL(X) ((X) >> largetTileSizeBitShift)
 #define MOD_FOR_LARGE_TILE(X) ((X) & 0x0F)
 // utility functions
-void updateScore(uint16_t addScore);
+void updateScore(uint16_t addScore) BANKED;
 BOOLEAN checkTilesFor(UBYTE column, UBYTE row, UBYTE type) NONBANKED;
 UBYTE getTileMapTile(UBYTE column, UBYTE row) NONBANKED;
 UBYTE getMapMetaTileArrayPosition(uint16_t x, uint16_t y) NONBANKED;

--- a/ZGB-template-master/src/Levels.c
+++ b/ZGB-template-master/src/Levels.c
@@ -1,5 +1,4 @@
-#pragma bank 255
-#include <gb/gb.h>
+#include "Banks/SetAutoBank.h"
 #include "StateGame.h"
 // map descriptors
 // 0 grass
@@ -14,7 +13,8 @@
 // 1   2
 // |   |
 // - 4 -
-const void __at(255) __bank_level1Map;
+
+BANKREF(level1Map)
 // emerald count 30
 const unsigned char level1Map[] = {
 	4,  0,  0,  0, BG,  0,  0,  0,  0,  0,  6,  3,  3,  3,  1, // "S   B     HHHHS", 
@@ -29,7 +29,7 @@ const unsigned char level1Map[] = {
    EM, EM,  0,  0, 10,  3,  3,  3,  3,  3,  9,  0,  0, EM, EM, // "CC  HHHHHHH  CC",
 };
 
-const void __at(255) __bank_level2Map;
+BANKREF(level2Map)
 // emerald count 41
 const unsigned char level2Map[] = {
 	2,  3,  3,  3,  3,  5,  0,  0, BG,  0, BG,  0,  0,  6,  1, // "SHHHHH  B B  HS", 
@@ -44,7 +44,7 @@ const unsigned char level2Map[] = {
    EM, EM,  0,  0,  0, 10,  3,  3,  3,  3,  9,  0,  0,  0,  0, // "CC   HHHHHH    ",
 };
 
-const void __at(255) __bank_level3Map;
+BANKREF(level3Map)
 // emerald count 51
 const unsigned char level3Map[] = {
 	2,  3,  3,  3,  5, BG,  0, BG,  0, BG,  6,  3,  3,  3,  1, // "SHHHHB B BHHHHS",
@@ -59,7 +59,7 @@ const unsigned char level3Map[] = {
    EM, EM,  0,  0,  0, EM,  0, 11,  0, EM,  0,  0,  0, EM, EM, // "CC   C H C   CC"
 };
 
-const void __at(255) __bank_level4Map;
+BANKREF(level4Map)
 // emerald count 65
 const unsigned char level4Map[] = {
 	2,  5, BG, EM, EM, EM, EM, BG, EM, EM, EM, EM, BG,  6,  1, // "SHBCCCCBCCCCBHS"
@@ -74,7 +74,7 @@ const unsigned char level4Map[] = {
    EM, EM, EM, EM, EM,  0, EM,  8, EM,  0, EM, EM, EM, EM, EM  // "CCCCC CHC CCCCC"
 };
 
-const void __at(255) __bank_level5Map;
+BANKREF(level5Map)
 // emerald count 77
 const unsigned char level5Map[] = {
      6,  3,  3,  3,  3,  3,  3,  7,  3,  3,  3,  3,  3,  3,  5, // SHHHHHHHHHHHHHS
@@ -89,7 +89,7 @@ const unsigned char level5Map[] = {
     10,  3,  3,  3,  3,  3,  3, 11,  3,  3,  3,  3,  3,  3,  9, // HHHHHHHHHHHHHHH
 };
 
-const void __at(255) __bank_level6Map;
+BANKREF(level6Map)
 // emerald count 52
 const unsigned char level6Map[] = {
      6,  3,  3,  3,  3,  7,  3,  7,  3,  7,  3,  3,  3,  3,  5, // SHHHHHHHHHHHHHS
@@ -104,7 +104,7 @@ const unsigned char level6Map[] = {
     10,  3, 11,  3,  3,  3,  3, 11,  3,  3,  3,  3, 11,  3,  9, // HHHHHHHHHHHHHHH
 };
 
-const void __at(255) __bank_level7Map;
+BANKREF(level7Map)
 // emerald count 92
 const unsigned char level7Map[] = {
      2,  5, EM, EM, EM, EM, EM,  4, EM, EM, EM, EM, EM,  6,  1, // SHCCCCCVCCCCCHS
@@ -119,7 +119,7 @@ const unsigned char level7Map[] = {
     EM, EM, EM, EM, EM, 10,  3, 11,  3,  9, EM, EM, EM, EM, EM, // CCCCCHHHHHCCCCC
 };
 
-const void __at(255) __bank_level8Map;
+BANKREF(level8Map)
 // emerald count 63
 const unsigned char level8Map[] = {
      6,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  5, // HHHHHHHHHHHHHHS
@@ -134,7 +134,7 @@ const unsigned char level8Map[] = {
     10,  3,  3,  3,  3,  3, 11,  3, 11,  3,  3,  3,  3,  3,  9, // HHHHHHHHHHHHHHH
 };
 
-const void __at(255) __bank_levelDebugMap;
+BANKREF(levelDebugMap)
 // emerald count 63
 const unsigned char levelDebugMap[] = {
      6,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  5, // 

--- a/ZGB-template-master/src/SpriteBag.c
+++ b/ZGB-template-master/src/SpriteBag.c
@@ -93,10 +93,7 @@ void setBagState(Sprite* bag, UBYTE bagState) BANKED {
 }
 
 void restoreStaticBag(Sprite* bag) BANKED {
-    UBYTE currentColumn = LARGE_TILE_FROM_PIXEL(bag->x - mapBoundLeft);
-    UBYTE currentRow = LARGE_TILE_FROM_PIXEL(bag->y - mapBoundUp);
-    UBYTE currentCell = currentRow * mapMetaWidth + currentColumn;
-
+    const UBYTE currentCell = getMapMetaTileArrayPosition(bag->x, bag->y);
     setBagState(bag, stateStatic);
     deactivateBag(bag, (levelMap[currentCell] & tunnelMask) != 0 ? bagOnTunnel : bagOnGrass);
 }
@@ -140,10 +137,7 @@ static void crushEnemiesUnderBag(void) {
 }
 
 static void finalizePushedBag(void) {
-    UBYTE currentColumn = LARGE_TILE_FROM_PIXEL(THIS->x - mapBoundLeft);
-    UBYTE currentRow = LARGE_TILE_FROM_PIXEL(THIS->y - mapBoundUp);
-    UBYTE currentCell = currentRow * mapMetaWidth + currentColumn;
-
+    const UBYTE currentCell = getMapMetaTileArrayPosition(THIS->x, THIS->y);
     if (bagCanFallInCellBelow(THIS)) {
         setBagState(THIS, stateFalling);
     } else {
@@ -188,25 +182,28 @@ void UPDATE(void) {
         }
     // else if is falling down as a bag or as a pile of gold
     } else if (THIS->custom_data[bagStatus] == stateFalling && THIS->y <= mapBoundDown) {
-        if (MOD_FOR_LARGE_TILE(THIS->y)) {
+        if (isBagAlignedToMetaCell(THIS) == FALSE) {
             THIS->custom_data[bagFallCounter]++;
             THIS->y++;
             crushEnemiesUnderBag();
         } else {
-            UBYTE cellBelow = getMapMetaTileArrayPosition(THIS->x, THIS->y) + mapMetaWidth;
-            uint8_t column = TILE_FROM_PIXEL(THIS->x);
-            uint8_t row = 2 + TILE_FROM_PIXEL(THIS->y);
             if (bagCanFallInCellBelow(THIS)) {
+                uint8_t column = TILE_FROM_PIXEL(THIS->x);
+                uint8_t row = 2 + TILE_FROM_PIXEL(THIS->y);
+                const UBYTE currentCell = getMapMetaTileArrayPosition(THIS->x, THIS->y);
+                UBYTE cellBelow = currentCell + mapMetaWidth;
                 if ((levelMap[cellBelow] & metaTileGold) != 0) {
                     levelMap[cellBelow] &= (UBYTE)~metaTileGold;
                 }
+                levelMap[cellBelow] |= J_DOWN;
+                levelMap[currentCell] |= J_UP;
                 setBagTiles(column, row, tileBlack);
                 THIS->custom_data[bagFallCounter]++;
                 THIS->y++;
                 crushEnemiesUnderBag();
             } else {
                 // solid ground or reach end of map
-                if (THIS->custom_data[bagFallCounter] >= largeTileSize && THIS->custom_data[bagStatus] == stateFalling) {
+                if (THIS->custom_data[bagFallCounter] >= largeTileSize * 2 && THIS->custom_data[bagStatus] == stateFalling) {
                     SpriteManagerAdd(SpriteGold, THIS->x, THIS->y);
                     SpriteManagerRemoveSprite(THIS);
                 } 

--- a/ZGB-template-master/src/SpriteGold.c
+++ b/ZGB-template-master/src/SpriteGold.c
@@ -122,8 +122,6 @@ void UPDATE(void) {
     }
 
     if (timer == 0) {
-        levelMap[getMapMetaTileArrayPosition(THIS->x, THIS->y)] &= tunnelMask;
-        clearGoldBackground();
         SpriteManagerRemoveSprite(THIS);
     } else {
         setGoldTimer(timer - 1);

--- a/ZGB-template-master/src/StateGame.c
+++ b/ZGB-template-master/src/StateGame.c
@@ -12,17 +12,36 @@
 #include "StateGame.h"
 #include "SpritePlayer.h"
 
+IMPORT_MAP(levelDebug);
+IMPORT_MAP(level1);
+IMPORT_MAP(level2);
+IMPORT_MAP(level3);
+IMPORT_MAP(level4);
+IMPORT_MAP(level5);
+IMPORT_MAP(level6);
+IMPORT_MAP(level7);
+IMPORT_MAP(level8);
+
 extern const UBYTE direction;
 extern const UBYTE oppositeDirection;
 
+BANKREF_EXTERN(level1Map)
 extern const unsigned char level1Map[150];
+BANKREF_EXTERN(level2Map)
 extern const unsigned char level2Map[150];
+BANKREF_EXTERN(level3Map)
 extern const unsigned char level3Map[150];
+BANKREF_EXTERN(level4Map)
 extern const unsigned char level4Map[150];
+BANKREF_EXTERN(level5Map)
 extern const unsigned char level5Map[150];
+BANKREF_EXTERN(level6Map)
 extern const unsigned char level6Map[150];
+BANKREF_EXTERN(level7Map)
 extern const unsigned char level7Map[150];
+BANKREF_EXTERN(level8Map)
 extern const unsigned char level8Map[150];
+BANKREF_EXTERN(levelDebugMap)
 extern const unsigned char levelDebugMap[150];
 
 extern uint8_t fx_00[];
@@ -114,8 +133,6 @@ void copyTileMapToRam(uint8_t levelToLoadBank, struct MapInfo *levelToLoad) NONB
 	// copy everything
 	currentInMemoryLevel = *levelToLoad;
 	// the data in the array is filled in by copyLevelMapToRam
-	// now copy the actual map data inside the array
-	// memcpy(tileMap, levelToLoad->data, currentInMemoryLevel.width * currentInMemoryLevel.height);
 	// redefine the pointer to my in memory array
 	currentInMemoryLevel.data = tileMap;
 	currentInMemoryLevel.width = 32;
@@ -124,7 +141,7 @@ void copyTileMapToRam(uint8_t levelToLoadBank, struct MapInfo *levelToLoad) NONB
 	SWITCH_ROM(__save);
 }
 
-void copyLevelMapToRam(unsigned char *mapToLoad[], uint8_t levelToLoadBank, struct MapInfo *levelToLoad) NONBANKED {
+void copyLevelMapToRam(const unsigned char *mapToLoad, uint8_t levelToLoadBank, struct MapInfo *levelToLoad) NONBANKED {
 	// uint8_t __save = CURRENT_BANK;
 	// SWITCH_ROM(mapToLoadBank);
 	memcpy(levelMap, mapToLoad, 150);
@@ -188,7 +205,7 @@ Sprite* activateBag(uint8_t bagcell) BANKED {
 }
 
 
-void updateScore(uint16_t addScore) {
+void updateScore(uint16_t addScore) BANKED {
 	score += addScore;
 	paintScore();
 }
@@ -291,10 +308,10 @@ static void resetLevelState(void) {
 	isDying = 0;
 	deathRespawnQueued = FALSE;
 	deathRespawnTimer = 0;
+	SpriteManagerReset();
 	enemyCountOnScreen = 0;
 	enemySpawned = 0;
 	spawnTimer = 0;
-	SpriteManagerReset();
 	scroll_target = SpriteManagerAdd(SpritePlayer, 136, 160);
 	paintScore();
 }
@@ -335,50 +352,41 @@ static void loadLevel(UBYTE level) {
 	// add first the spriteManager only then load the level
 	switch (level) {
 		case 0:
-		    IMPORT_MAP(levelDebug);
-			copyLevelMapToRam(&levelDebugMap, BANK(levelDebug), &levelDebug);
+			copyLevelMapToRam(levelDebugMap, BANK(levelDebug), &levelDebug);
 			diamonds = 99;
 		break;
 		case 1:
-			IMPORT_MAP(level1);
-			copyLevelMapToRam(&level1Map, BANK(level1), &level1);
+			copyLevelMapToRam(level1Map, BANK(level1), &level1);
 			diamonds = 30;
 		break;
 		case 2: 
-			IMPORT_MAP(level2);
-			copyLevelMapToRam(&level2Map, BANK(level2), &level2);
+			copyLevelMapToRam(level2Map, BANK(level2), &level2);
 			diamonds = 41;
 		break;
 		case 3: 
-			IMPORT_MAP(level3);
-			copyLevelMapToRam(&level3Map, BANK(level3), &level3);
+			copyLevelMapToRam(level3Map, BANK(level3), &level3);
 			diamonds = 51;
 		break;
 		case 4: 
-			IMPORT_MAP(level4);
-			copyLevelMapToRam(&level4Map, BANK(level4), &level4);
+			copyLevelMapToRam(level4Map, BANK(level4), &level4);
 			diamonds = 65;
 		break;
 		case 5: {
-			IMPORT_MAP(level5);
-			copyLevelMapToRam(&level5Map, BANK(level5), &level5);
+			copyLevelMapToRam(level5Map, BANK(level5), &level5);
 			diamonds = 77;
 		} break;
 		case 6: {
 			// Level tilemaps are synthesized from levelMap, so later levels can
 			// reuse the same MapInfo metadata as long as the dimensions match.
-			IMPORT_MAP(level6);
-			copyLevelMapToRam(&level6Map, BANK(level6), &level6);
+			copyLevelMapToRam(level6Map, BANK(level6), &level6);
 			diamonds = 52;
 		} break;
 		case 7: {
-			IMPORT_MAP(level7);
-			copyLevelMapToRam(&level7Map, BANK(level7), &level7);
+			copyLevelMapToRam(level7Map, BANK(level7), &level7);
 			diamonds = 92;
 		} break;
 		case 8: {
-			IMPORT_MAP(level8);
-			copyLevelMapToRam(&level8Map, BANK(level8), &level8);
+			copyLevelMapToRam(level8Map, BANK(level8), &level8);
 			diamonds = 63;
 		} break;
 		default:


### PR DESCRIPTION
## Summary

This PR fixes the banking and bag-fall regressions tracked in #28.

## What changed

- switched the custom `level*Map[]` data in `Levels.c` to explicit `BANKREF(...)` references and matched the corresponding `BANKREF_EXTERN(...)` declarations and `BANK(...)` call sites in `StateGame.c`
- made `updateScore()` `BANKED` so score updates from autobanked sprite modules are emitted as bank-safe calls
- reordered `resetLevelState()` so `SpriteManagerReset()` runs before `enemyCountOnScreen` is reset, preventing enemy-count underflow during sprite destruction on level reset / respawn
- updated bag fall handling so bags only break into gold after falling more than one full meta-cell
- synchronized falling-bag shaft updates with `levelMap` by preserving vertical tunnel bits as the bag clears cells below it
- simplified some bag cell lookups to use `getMapMetaTileArrayPosition()` consistently
- removed duplicate gold-cell cleanup from the `timer == 0` path in `SpriteGold.c` and left cleanup centralized in `DESTROY()`

## Why

The recent banking cleanup exposed two cross-bank issues:

- custom level arrays need exact bank-symbol name alignment when using `BANKREF()`
- sprite code cannot safely plain-call shared gameplay helpers that live in another bank

Separately, bag and reset behavior had three gameplay problems:

- the enemy HUD counter could underflow and then block future spawns
- one-cell bag falls broke into gold too early compared to original Digger behavior
- falling bags could stop over visually open black shafts because the rendered shaft and the logical tunnel bits were drifting out of sync

## Validation

- `cd ZGB-template-master/src && make gb`

Closes #28.
